### PR TITLE
Add BlockRun.AI as LLM Provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,15 @@ QWEN_API_KEY=your_qwen_api_key_here
 # 获取地址: https://aistudio.google.com/app/apikey
 GEMINI_API_KEY=your_gemini_api_key_here
 
+# BlockRun.AI (可选 - x402 micropayments)
+# Pay-per-request via USDC on Base chain. No API keys needed.
+# Access GPT-4o, Claude, Gemini, DeepSeek via single wallet.
+# Get started: https://blockrun.ai/docs
+#
+# SECURITY: Your private key NEVER leaves your machine.
+# It's only used for local EIP-712 signing - only signatures are sent.
+BLOCKRUN_WALLET_KEY=your_base_chain_private_key_here
+
 # 自定义 Base URL (可选 - 用于代理服务)
 LLM_BASE_URL=
 

--- a/README.md
+++ b/README.md
@@ -82,8 +82,11 @@ Intelligent Multi-Agent Quantitative Trading Bot based on the **Adversarial Deci
 | **OpenAI (GPT)** | ✅ Supported | [Get API Key](https://platform.openai.com) |
 | **Claude** | ✅ Supported | [Get API Key](https://console.anthropic.com) |
 | **Gemini** | ✅ Supported | [Get API Key](https://aistudio.google.com) |
+| **BlockRun.AI** | ✅ Supported | [Get Started](https://blockrun.ai/docs) |
 | **Grok** | 🗓️ Coming Soon | [Get API Key](https://console.x.ai) |
 | **Kimi** | 🗓️ Coming Soon | [Get API Key](https://platform.moonshot.cn) |
+
+> **BlockRun.AI**: Pay-per-request via USDC micropayments on Base chain. Access GPT-4o, Claude, Gemini, DeepSeek through a single wallet - no API keys needed. Your private key never leaves your machine.
 
 ---
 
@@ -395,6 +398,7 @@ LLM-TradeBot/
 │   │   ├── claude_client.py  # Anthropic Claude
 │   │   ├── qwen_client.py    # Alibaba Qwen
 │   │   ├── gemini_client.py  # Google Gemini
+│   │   ├── blockrun_client.py # BlockRun.AI (x402 micropayments)
 │   │   └── factory.py    # LLM Factory
 │   ├── monitoring/        # Monitoring & Logging
 │   ├── risk/              # Risk Management

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,9 @@ websockets==12.0
 # DeepSeek API
 openai==1.6.1
 
+# BlockRun.AI (x402 micropayments)
+blockrun-llm>=0.1.0
+
 # 数据存储
 redis==5.0.1
 sqlalchemy==2.0.23

--- a/src/llm/__init__.py
+++ b/src/llm/__init__.py
@@ -10,6 +10,7 @@ LLM 模块
 - Claude (Anthropic)
 - Qwen (通义千问)
 - Gemini (Google)
+- BlockRun (x402 micropayments - GPT-4o, Claude, Gemini, DeepSeek via single wallet)
 
 使用示例：
 
@@ -36,6 +37,7 @@ from .deepseek_client import DeepSeekClient
 from .claude_client import ClaudeClient
 from .qwen_client import QwenClient
 from .gemini_client import GeminiClient
+from .blockrun_client import BlockRunClient
 
 __all__ = [
     # 核心接口
@@ -52,4 +54,5 @@ __all__ = [
     "ClaudeClient",
     "QwenClient",
     "GeminiClient",
+    "BlockRunClient",
 ]

--- a/src/llm/blockrun_client.py
+++ b/src/llm/blockrun_client.py
@@ -1,0 +1,185 @@
+"""
+BlockRun.AI Client Implementation
+=================================
+
+Pay-per-request AI gateway using x402 micropayments on Base chain.
+Access GPT-4o, Claude, Gemini, DeepSeek, and more - no API keys needed.
+
+SECURITY NOTE - Private Key Handling:
+=====================================
+Your private key NEVER leaves your machine. Here's what happens:
+
+1. Key stays local - only used to sign an EIP-712 typed data message
+2. Only the SIGNATURE is sent in the PAYMENT-SIGNATURE header
+3. BlockRun verifies the signature on-chain via facilitator
+4. Your actual private key is NEVER transmitted to any server
+
+This is the same security model as signing a MetaMask transaction.
+
+Setup:
+    1. Get a Base chain wallet with USDC
+    2. Set BLOCKRUN_WALLET_KEY in .env (your private key)
+    3. Select provider "blockrun" in the dashboard
+
+Available Models:
+    - openai/gpt-4o, openai/gpt-4o-mini
+    - anthropic/claude-sonnet-4, anthropic/claude-3-5-sonnet
+    - google/gemini-2.5-pro, google/gemini-2.5-flash
+    - deepseek/deepseek-chat, deepseek/deepseek-reasoner
+    - x-ai/grok-3
+
+Docs: https://blockrun.ai/docs
+"""
+
+import os
+from typing import Dict, Any, List
+
+from .base import BaseLLMClient, LLMConfig, ChatMessage, LLMResponse
+
+
+class BlockRunClient(BaseLLMClient):
+    """
+    BlockRun.AI LLM Client
+
+    Uses x402 micropayments on Base chain - pay per request in USDC.
+    No traditional API keys needed, just a wallet private key.
+    """
+
+    DEFAULT_BASE_URL = "https://blockrun.ai/api/v1"
+    DEFAULT_MODEL = "openai/gpt-4o"
+    PROVIDER = "blockrun"
+
+    def __init__(self, config: LLMConfig):
+        """
+        Initialize BlockRun client.
+
+        Args:
+            config: LLMConfig where api_key is your Base chain wallet private key
+                   (or set BLOCKRUN_WALLET_KEY env var)
+
+        Note:
+            Your private key is used ONLY for local EIP-712 signing.
+            The key NEVER leaves your machine - only signatures are sent.
+        """
+        # Import blockrun SDK
+        try:
+            from blockrun_llm import LLMClient as BlockRunSDK
+        except ImportError:
+            raise ImportError(
+                "blockrun-llm package not installed. "
+                "Install with: pip install blockrun-llm"
+            )
+
+        # Get private key from config or env
+        private_key = config.api_key or os.environ.get("BLOCKRUN_WALLET_KEY")
+        if not private_key:
+            raise ValueError(
+                "BlockRun requires a wallet private key. "
+                "Set BLOCKRUN_WALLET_KEY in .env or pass as api_key. "
+                "NOTE: Your key never leaves your machine - only signatures are sent."
+            )
+
+        # Store config
+        self.config = config
+        self.model = config.model or self.DEFAULT_MODEL
+        self.base_url = config.base_url or self.DEFAULT_BASE_URL
+
+        # Initialize BlockRun SDK
+        # The SDK handles x402 payment flow internally
+        self._sdk = BlockRunSDK(
+            private_key=private_key,
+            api_url=self.base_url.replace("/v1", ""),  # SDK adds /v1 internally
+            timeout=float(config.timeout),
+        )
+
+    def _build_headers(self) -> Dict[str, str]:
+        """Not used - SDK handles headers including payment signatures."""
+        return {}
+
+    def _build_request_body(
+        self,
+        messages: List[ChatMessage],
+        **kwargs
+    ) -> Dict[str, Any]:
+        """Not used - SDK builds request internally."""
+        return {}
+
+    def _parse_response(self, response: Dict[str, Any]) -> LLMResponse:
+        """Not used - SDK parses response internally."""
+        return LLMResponse(content="", model=self.model, provider=self.PROVIDER)
+
+    def chat(
+        self,
+        system_prompt: str,
+        user_prompt: str,
+        **kwargs
+    ) -> LLMResponse:
+        """
+        Send a chat request via BlockRun.
+
+        Args:
+            system_prompt: System instructions
+            user_prompt: User message
+            **kwargs: Additional params (temperature, max_tokens)
+
+        Returns:
+            LLMResponse with the assistant's reply
+        """
+        messages = [
+            ChatMessage(role="system", content=system_prompt),
+            ChatMessage(role="user", content=user_prompt)
+        ]
+        return self.chat_messages(messages, **kwargs)
+
+    def chat_messages(
+        self,
+        messages: List[ChatMessage],
+        **kwargs
+    ) -> LLMResponse:
+        """
+        Multi-turn chat via BlockRun.
+
+        The SDK automatically handles the x402 payment flow:
+        1. Sends request -> receives 402 with payment requirements
+        2. Signs payment locally with your private key
+        3. Retries request with payment signature
+        4. Returns response
+
+        Args:
+            messages: List of ChatMessage objects
+            **kwargs: Additional params
+
+        Returns:
+            LLMResponse with the assistant's reply
+        """
+        # Convert ChatMessage to dict format
+        msg_list = [{"role": m.role, "content": m.content} for m in messages]
+
+        # Call BlockRun SDK
+        result = self._sdk.chat_completion(
+            model=self.model,
+            messages=msg_list,
+            max_tokens=kwargs.get("max_tokens", self.config.max_tokens),
+            temperature=kwargs.get("temperature", self.config.temperature),
+        )
+
+        # Convert SDK response to LLMResponse
+        return LLMResponse(
+            content=result.choices[0].message.content,
+            model=result.model,
+            provider=self.PROVIDER,
+            usage={
+                "prompt_tokens": result.usage.prompt_tokens if result.usage else 0,
+                "completion_tokens": result.usage.completion_tokens if result.usage else 0,
+                "total_tokens": result.usage.total_tokens if result.usage else 0,
+            },
+            raw_response=None,  # SDK doesn't expose raw response
+        )
+
+    def get_wallet_address(self) -> str:
+        """Get the wallet address being used for payments."""
+        return self._sdk.get_wallet_address()
+
+    def close(self):
+        """Close the HTTP client."""
+        self._sdk.close()

--- a/src/llm/factory.py
+++ b/src/llm/factory.py
@@ -12,6 +12,7 @@ from .deepseek_client import DeepSeekClient
 from .claude_client import ClaudeClient
 from .qwen_client import QwenClient
 from .gemini_client import GeminiClient
+from .blockrun_client import BlockRunClient
 
 
 # 注册所有支持的提供商
@@ -21,6 +22,7 @@ PROVIDERS: Dict[str, Type[BaseLLMClient]] = {
     "claude": ClaudeClient,
     "qwen": QwenClient,
     "gemini": GeminiClient,
+    "blockrun": BlockRunClient,
 }
 
 


### PR DESCRIPTION
## Summary

Add [BlockRun.AI](https://blockrun.ai) as a new LLM provider for LLM-TradeBot.

BlockRun.AI is a pay-per-request AI gateway using x402 micropayments on Base chain:
- Access GPT-4o, Claude, Gemini, DeepSeek via a single wallet
- No traditional API keys needed - just a Base chain wallet with USDC
- Pay only for what you use (micropayments per request)

### Why BlockRun for Trading Bots?

- **No API key management** - Perfect for autonomous agents
- **Multi-model access** - Switch between models without managing multiple API keys
- **Crypto-native** - Pay in USDC on Base chain, ideal for DeFi/trading applications
- **Cost-effective** - Pay-per-request eliminates monthly subscription overhead

### Security

Your private key **NEVER leaves your machine**. It's only used for local EIP-712 signing - only signatures are transmitted. Same security model as signing a MetaMask transaction.

## Changes

- `src/llm/blockrun_client.py` - New client using official `blockrun-llm` SDK
- `src/llm/factory.py` - Register "blockrun" provider
- `src/llm/__init__.py` - Export BlockRunClient
- `.env.example` - Add BLOCKRUN_WALLET_KEY config
- `requirements.txt` - Add blockrun-llm dependency
- `README.md` - Document BlockRun in supported models

## Usage

```bash
# .env
BLOCKRUN_WALLET_KEY=your_base_chain_private_key

# Select "blockrun" as provider in Dashboard
# Use model format: openai/gpt-4o, anthropic/claude-sonnet-4, etc.
```

## Links

- [BlockRun Docs](https://blockrun.ai/docs)
- [Python SDK](https://github.com/blockrunai/blockrun-llm)
- [x402 Protocol](https://x402.org)